### PR TITLE
s3 bucket should be the ares one

### DIFF
--- a/docs/01-build.md
+++ b/docs/01-build.md
@@ -63,7 +63,7 @@ To setup your environment please expand one of the following dropdown sections (
             "Action": [
                 "s3:List*"
             ],
-            "Resource": "arn:aws:s3:::identity-ex-<>"
+            "Resource": "arn:aws:s3:::identity-ex-ares-*"
         }
     ]
 }


### PR DESCRIPTION
In module 2, task 3 we want to list the ares data bucket, not a custom one with '<>', so we need to specify 'ares' here.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
